### PR TITLE
Add a jupyter file, for try largest batch

### DIFF
--- a/largest_batch_size_test.ipynb
+++ b/largest_batch_size_test.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright (c) 2023, HLSS. All rights reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from predictors import QCNet\n",
+    "from datamodules.argoverse_v2_datamodule import ArgoverseV2DataModule\n",
+    "import torch\n",
+    "\n",
+    "torch.cuda.set_device(3)\n",
+    "DATA_ROOT = '~/dataset/argoverse/motion_forecasting'\n",
+    "BATCH_SIZE = 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_module = ArgoverseV2DataModule(DATA_ROOT,1,1,1,False)\n",
+    "data_module.setup()\n",
+    "dataset = data_module.train_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = QCNet(\n",
+    "            dataset = 'argoverse_v2', \n",
+    "            input_dim = 2, \n",
+    "            hidden_dim = 128, \n",
+    "            output_dim = 2, \n",
+    "            output_head = False, \n",
+    "            num_historical_steps = 50, \n",
+    "            num_future_steps = 60, \n",
+    "            num_modes = 6, \n",
+    "            num_recurrent_steps = 3, \n",
+    "            num_freq_bands = 64, \n",
+    "            num_map_layers = 1, \n",
+    "            num_agent_layers = 2, \n",
+    "            num_dec_layers = 2, \n",
+    "            num_heads = 8, \n",
+    "            head_dim = 16, \n",
+    "            dropout = 0.1, \n",
+    "            pl2pl_radius = 150, \n",
+    "            time_span = 10, \n",
+    "            pl2a_radius = 50, \n",
+    "            a2a_radius = 50, \n",
+    "            num_t2m_steps = 30, \n",
+    "            pl2m_radius = 150, \n",
+    "            a2m_radius = 150, \n",
+    "            lr = 0.0005, \n",
+    "            weight_decay = 0.0001, \n",
+    "            T_max = 64, \n",
+    "            submission_dir = './', \n",
+    "            submission_file_name = 'submission'\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "large8files=[\n",
+    "    'ad7e93e9-a705-43dc-be19-8d6530e113ef.pkl',\n",
+    "    '721cb053-b5d7-4fda-a9c5-e5057ae218fd.pkl',\n",
+    "    '0c1e8c81-eb87-40e3-b8ae-f2fb7c42c9ce.pkl',\n",
+    "    '6ade6821-7255-4aba-b8ca-991a21fdb375.pkl',\n",
+    "    '75b84bd2-3090-41f6-a4fd-263bd335ef15.pkl',\n",
+    "    '7f308986-6ed2-493a-8862-007f642c4cee.pkl',\n",
+    "    'a082c53b-4cc6-45ea-8519-efbf3aa73262.pkl',\n",
+    "    '59e210b5-564f-43f1-a45c-1d9d5e51e5f6.pkl'\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch_geometric.data import Batch\n",
+    "batch = Batch.from_data_list([dataset.transform(dataset.get(dataset.processed_file_names.index(x))) for x in large8files[:BATCH_SIZE]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.cuda()\n",
+    "optimers, lr_schedulers = model.configure_optimizers()\n",
+    "loss = model.training_step(batch.cuda(), 0)\n",
+    "loss.backward()\n",
+    "for optimer in optimers:\n",
+    "    optimer.step()\n",
+    "    optimer.zero_grad()\n",
+    "for lr_schedulers in lr_schedulers:\n",
+    "    lr_schedulers.step()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "QCNet",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
#2 , the VRAM leak issue.
This is not a memory leak, but rather a result of a significant disparity in the size of input samples. Let's take the processed training data file size as an example. There are only 110 samples larger than 500KB and fewer than 20,000 samples larger than 300KB (considering there are nearly 200,000 samples in total).

During the training process, batches are randomly composed (batch_size << samples). In extreme cases, the largest samples can easily trigger an OOM error. The seemingly leaking memory is actually caused by the generation of larger batches. If you call `torch.cuda.empty_cache()`, you will see that the actual memory usage fluctuates.

I've written this Jupyter script to help you confirm if your GPU can handle extremely large batch. By manually adjusting the `BATCH_SIZE`, you can determine the appropriate size for training. However, I cannot guarantee how much space should be reserved as safe, as someone mentioned experiencing an OOM error with a batch size of 2 on a 24GB GPU, while this script was able to run successfully.